### PR TITLE
Prevent infinite loops in pairwise generator

### DIFF
--- a/pairwise.py
+++ b/pairwise.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Dict, Iterable, List, Tuple, FrozenSet
+
+
+Pair = FrozenSet[Tuple[str, object]]
+
+
+def _pair_key(p1: str, v1, p2: str, v2) -> Pair:
+    """Return a canonical representation for a pair of parameter values."""
+    return frozenset(((p1, v1), (p2, v2)))
+
+
+def generate_pairwise_tests(parameters: Dict[str, Iterable[object]]) -> List[Dict[str, object]]:
+    """Generate a set of test cases that provides pairwise coverage.
+
+    Parameters
+    ----------
+    parameters:
+        Mapping of parameter names to iterables of possible values.
+
+    Returns
+    -------
+    List[Dict[str, object]]
+        A list of dictionaries representing test cases.
+
+    Raises
+    ------
+    ValueError
+        If no progress can be made towards covering new pairs, which would
+        otherwise result in an infinite loop.
+    """
+
+    param_names = list(parameters)
+    # Build the set of all pairs that must be covered
+    uncovered_pairs: set[Pair] = set()
+    for p1, p2 in combinations(param_names, 2):
+        for v1 in parameters[p1]:
+            for v2 in parameters[p2]:
+                uncovered_pairs.add(_pair_key(p1, v1, p2, v2))
+
+    tests: List[Dict[str, object]] = []
+    while uncovered_pairs:
+        test_case: Dict[str, object] = {}
+        # Choose a value for each parameter greedily based on remaining coverage
+        for param in param_names:
+            best_value = None
+            best_score = -1
+            for value in parameters[param]:
+                score = 0
+                for other in param_names:
+                    if other == param:
+                        continue
+                    if other in test_case:
+                        pair = _pair_key(param, value, other, test_case[other])
+                        if pair in uncovered_pairs:
+                            score += 1
+                    else:
+                        for ov in parameters[other]:
+                            pair = _pair_key(param, value, other, ov)
+                            if pair in uncovered_pairs:
+                                score += 1
+                if score > best_score:
+                    best_value, best_score = value, score
+            test_case[param] = best_value
+
+        # Determine which uncovered pairs are exercised by this test case
+        pairs_in_new_case = set()
+        for p1, p2 in combinations(param_names, 2):
+            pair = _pair_key(p1, test_case[p1], p2, test_case[p2])
+            pairs_in_new_case.add(pair)
+
+        newly_covered = pairs_in_new_case & uncovered_pairs
+        if not newly_covered:
+            raise ValueError(
+                "Generated test case does not cover any new pairs; algorithm stalled"
+            )
+
+        tests.append(test_case)
+        uncovered_pairs -= newly_covered
+
+    return tests

--- a/pairwise.py
+++ b/pairwise.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from itertools import combinations
 from typing import Dict, Iterable, List, Tuple, FrozenSet
 
+import argparse
+import json
+import sys
+
 
 Pair = FrozenSet[Tuple[str, object]]
 
@@ -81,3 +85,52 @@ def generate_pairwise_tests(parameters: Dict[str, Iterable[object]]) -> List[Dic
         uncovered_pairs -= newly_covered
 
     return tests
+
+
+def _parse_cli_args(args: Iterable[str]) -> Dict[str, List[str]]:
+    """Parse command line parameter specifications.
+
+    Parameters are given as ``name=v1,v2`` strings. For example::
+
+        python pairwise.py size=small,large color=red,blue
+
+    Parameters
+    ----------
+    args:
+        Iterable of argument strings.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        Mapping of parameter names to lists of values.
+    """
+
+    parameters: Dict[str, List[str]] = {}
+    for arg in args:
+        if "=" not in arg:
+            raise ValueError(f"Invalid parameter specification: {arg!r}")
+        name, values = arg.split("=", 1)
+        parameters[name] = values.split(",") if values else []
+    return parameters
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Entry point for command line execution."""
+
+    parser = argparse.ArgumentParser(description="Generate pairwise test cases")
+    parser.add_argument(
+        "params",
+        nargs="+",
+        help="Parameters in the form name=v1,v2,...",
+    )
+    ns = parser.parse_args(argv)
+
+    parameters = _parse_cli_args(ns.params)
+    cases = generate_pairwise_tests(parameters)
+    for case in cases:
+        print(json.dumps(case))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/test_pairwise.py
+++ b/tests/test_pairwise.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
 from pairwise import generate_pairwise_tests
 
 
@@ -25,4 +30,23 @@ def test_generate_pairwise_binary_parameters():
                 for v2 in params[p2]:
                     expected_pairs.add(frozenset(((p1, v1), (p2, v2))))
 
+    assert seen_pairs == expected_pairs
+
+
+def test_cli_invocation_generates_cases(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "pairwise.py"
+    cmd = [sys.executable, str(script), "a=0,1", "b=0,1"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    cases = [json.loads(line) for line in result.stdout.strip().splitlines()]
+    seen_pairs = set()
+    for case in cases:
+        pair = frozenset((('a', case['a']), ('b', case['b'])))
+        seen_pairs.add(pair)
+
+    expected_pairs = {
+        frozenset((('a', a), ('b', b)))
+        for a in ['0', '1']
+        for b in ['0', '1']
+    }
     assert seen_pairs == expected_pairs

--- a/tests/test_pairwise.py
+++ b/tests/test_pairwise.py
@@ -1,0 +1,28 @@
+from pairwise import generate_pairwise_tests
+
+
+def test_generate_pairwise_binary_parameters():
+    params = {
+        "a": [0, 1],
+        "b": [0, 1],
+        "c": [0, 1],
+    }
+    cases = generate_pairwise_tests(params)
+
+    # Ensure all pairs are covered
+    seen_pairs = set()
+    names = list(params)
+    for case in cases:
+        for i, p1 in enumerate(names):
+            for p2 in names[i + 1 :]:
+                pair = frozenset(((p1, case[p1]), (p2, case[p2])))
+                seen_pairs.add(pair)
+
+    expected_pairs = set()
+    for i, p1 in enumerate(names):
+        for p2 in names[i + 1 :]:
+            for v1 in params[p1]:
+                for v2 in params[p2]:
+                    expected_pairs.add(frozenset(((p1, v1), (p2, v2))))
+
+    assert seen_pairs == expected_pairs


### PR DESCRIPTION
## Summary
- implement `generate_pairwise_tests` for pairwise coverage
- select parameter values based on all remaining uncovered pairs and stop when no progress is made
- add regression test ensuring generator terminates for binary parameters

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14d56025c8329aff9d8fe36adb737