### PR TITLE
Prevent infinite loops in pairwise generator

### DIFF
--- a/pairwise.py
+++ b/pairwise.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Dict, Iterable, List, Tuple, FrozenSet
+
+import json
+import sys
+
+
+Pair = FrozenSet[Tuple[str, object]]
+
+
+def _pair_key(p1: str, v1, p2: str, v2) -> Pair:
+    """Return a canonical representation for a pair of parameter values."""
+    return frozenset(((p1, v1), (p2, v2)))
+
+
+def generate_pairwise_tests(parameters: Dict[str, Iterable[object]]) -> List[Dict[str, object]]:
+    """Generate a set of test cases that provides pairwise coverage.
+
+    Parameters
+    ----------
+    parameters:
+        Mapping of parameter names to iterables of possible values.
+
+    Returns
+    -------
+    List[Dict[str, object]]
+        A list of dictionaries representing test cases.
+
+    Raises
+    ------
+    ValueError
+        If no progress can be made towards covering new pairs, which would
+        otherwise result in an infinite loop.
+    """
+
+    param_names = list(parameters)
+    # Build the set of all pairs that must be covered
+    uncovered_pairs: set[Pair] = set()
+    for p1, p2 in combinations(param_names, 2):
+        for v1 in parameters[p1]:
+            for v2 in parameters[p2]:
+                uncovered_pairs.add(_pair_key(p1, v1, p2, v2))
+
+    tests: List[Dict[str, object]] = []
+    while uncovered_pairs:
+        test_case: Dict[str, object] = {}
+        # Choose a value for each parameter greedily based on remaining coverage
+        for param in param_names:
+            best_value = None
+            best_score = -1
+            for value in parameters[param]:
+                score = 0
+                for other in param_names:
+                    if other == param:
+                        continue
+                    if other in test_case:
+                        pair = _pair_key(param, value, other, test_case[other])
+                        if pair in uncovered_pairs:
+                            score += 1
+                    else:
+                        for ov in parameters[other]:
+                            pair = _pair_key(param, value, other, ov)
+                            if pair in uncovered_pairs:
+                                score += 1
+                if score > best_score:
+                    best_value, best_score = value, score
+            test_case[param] = best_value
+
+        # Determine which uncovered pairs are exercised by this test case
+        pairs_in_new_case = set()
+        for p1, p2 in combinations(param_names, 2):
+            pair = _pair_key(p1, test_case[p1], p2, test_case[p2])
+            pairs_in_new_case.add(pair)
+
+        newly_covered = pairs_in_new_case & uncovered_pairs
+        if not newly_covered:
+            raise ValueError(
+                "Generated test case does not cover any new pairs; algorithm stalled"
+            )
+
+        tests.append(test_case)
+        uncovered_pairs -= newly_covered
+
+    return tests
+
+
+def _prompt_for_parameters() -> Dict[str, List[str]]:
+    """Interactively ask the user for parameter definitions.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        Mapping of parameter names to lists of values.
+    """
+
+    parameters: Dict[str, List[str]] = {}
+    while True:
+        print("Parameter name (or 'done' to finish): ", end="", file=sys.stderr, flush=True)
+        name = input().strip()
+        if name.lower() == "done" or name == "":
+            break
+        print(
+            f"Values for {name} (comma-separated): ",
+            end="",
+            file=sys.stderr,
+            flush=True,
+        )
+        values = input().strip()
+        parameters[name] = [v.strip() for v in values.split(",") if v.strip()]
+    return parameters
+
+
+def main() -> int:
+    """Entry point for command line execution."""
+
+    parameters = _prompt_for_parameters()
+    cases = generate_pairwise_tests(parameters)
+    for case in cases:
+        print(json.dumps(case))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,33 @@
-Test
+# Pairwise Test Generator
+
+This project provides a small utility for generating pairwise combinations of
+parameter values.
+
+## Usage
+
+Run the script and enter parameters when prompted.  Type `done` when you have
+finished entering parameters and their values:
+
+```
+python pairwise.py
+Parameter name (or 'done' to finish): size
+Values for size (comma-separated): small,large
+Parameter name (or 'done' to finish): color
+Values for color (comma-separated): red,blue
+Parameter name (or 'done' to finish): done
+{"size": "small", "color": "red"}
+{"size": "small", "color": "blue"}
+{"size": "large", "color": "red"}
+{"size": "large", "color": "blue"}
+```
+
+Each line of output is a JSON object representing one test case.
+
+## Testing
+
+Execute the test suite with:
+
+```
+python -m pytest -q
+```
+

--- a/tests/test_pairwise.py
+++ b/tests/test_pairwise.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+from pairwise import generate_pairwise_tests
+
+
+def test_generate_pairwise_binary_parameters():
+    params = {
+        "a": [0, 1],
+        "b": [0, 1],
+        "c": [0, 1],
+    }
+    cases = generate_pairwise_tests(params)
+
+    # Ensure all pairs are covered
+    seen_pairs = set()
+    names = list(params)
+    for case in cases:
+        for i, p1 in enumerate(names):
+            for p2 in names[i + 1 :]:
+                pair = frozenset(((p1, case[p1]), (p2, case[p2])))
+                seen_pairs.add(pair)
+
+    expected_pairs = set()
+    for i, p1 in enumerate(names):
+        for p2 in names[i + 1 :]:
+            for v1 in params[p1]:
+                for v2 in params[p2]:
+                    expected_pairs.add(frozenset(((p1, v1), (p2, v2))))
+
+    assert seen_pairs == expected_pairs
+
+
+def test_cli_invocation_generates_cases():
+    script = Path(__file__).resolve().parent.parent / "pairwise.py"
+    cmd = [sys.executable, str(script)]
+    user_input = "a\n0,1\nb\n0,1\ndone\n"
+    result = subprocess.run(
+        cmd, input=user_input, capture_output=True, text=True, check=True
+    )
+
+    cases = [
+        json.loads(line)
+        for line in result.stdout.splitlines()
+        if line.startswith("{")
+    ]
+    seen_pairs = {
+        frozenset((("a", case["a"]), ("b", case["b"])))
+        for case in cases
+    }
+
+    expected_pairs = {
+        frozenset((("a", a), ("b", b)))
+        for a in ["0", "1"]
+        for b in ["0", "1"]
+    }
+    assert seen_pairs == expected_pairs


### PR DESCRIPTION
## Summary
- implement `generate_pairwise_tests` for pairwise coverage
- select parameter values based on all remaining uncovered pairs and stop when no progress is made
- add regression test ensuring generator terminates for binary parameters
- restore interactive CLI to prompt for parameters until user enters `done`
- add CLI regression test verifying all pairs are produced and document usage in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14d56025c8329aff9d8fe36adb737