### PR TITLE
Add interactive pairwise parameter input

### DIFF
--- a/pairwise.py
+++ b/pairwise.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from itertools import combinations
 from typing import Dict, Iterable, List, Tuple, FrozenSet
 
-import argparse
 import json
 import sys
 
@@ -87,45 +86,28 @@ def generate_pairwise_tests(parameters: Dict[str, Iterable[object]]) -> List[Dic
     return tests
 
 
-def _parse_cli_args(args: Iterable[str]) -> Dict[str, List[str]]:
-    """Parse command line parameter specifications.
+def _prompt(message: str) -> str:
+    """Display ``message`` and return the user's response."""
+    print(message, end="", file=sys.stderr)
+    return input()
 
-    Parameters are given as ``name=v1,v2`` strings. For example::
 
-        python pairwise.py size=small,large color=red,blue
-
-    Parameters
-    ----------
-    args:
-        Iterable of argument strings.
-
-    Returns
-    -------
-    Dict[str, List[str]]
-        Mapping of parameter names to lists of values.
-    """
+def main() -> int:
+    """Entry point for interactive pairwise test generation."""
+    print(
+        "Enter parameters to generate pairwise combinations.",
+        file=sys.stderr,
+    )
+    print("Leave the parameter name blank to finish.\n", file=sys.stderr)
 
     parameters: Dict[str, List[str]] = {}
-    for arg in args:
-        if "=" not in arg:
-            raise ValueError(f"Invalid parameter specification: {arg!r}")
-        name, values = arg.split("=", 1)
-        parameters[name] = values.split(",") if values else []
-    return parameters
+    while True:
+        name = _prompt("Parameter name: ").strip()
+        if not name:
+            break
+        values = _prompt(f"Values for {name} (comma-separated): ").strip()
+        parameters[name] = [v.strip() for v in values.split(",")] if values else []
 
-
-def main(argv: List[str] | None = None) -> int:
-    """Entry point for command line execution."""
-
-    parser = argparse.ArgumentParser(description="Generate pairwise test cases")
-    parser.add_argument(
-        "params",
-        nargs="+",
-        help="Parameters in the form name=v1,v2,...",
-    )
-    ns = parser.parse_args(argv)
-
-    parameters = _parse_cli_args(ns.params)
     cases = generate_pairwise_tests(parameters)
     for case in cases:
         print(json.dumps(case))

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,15 @@
-Test
+# Pairwise Generator
+
+Generate pairwise combinations of parameter values.
+
+## Interactive usage
+
+Run the script and follow the prompts:
+
+```
+python pairwise.py
+```
+
+Enter a parameter name when prompted, then provide its values separated by commas.
+Leave the name blank when you are finished. Each generated combination is printed as
+a JSON object on its own line.

--- a/tests/test_pairwise.py
+++ b/tests/test_pairwise.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 import sys
 
+# Ensure the project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 from pairwise import generate_pairwise_tests
 
 
@@ -33,10 +35,13 @@ def test_generate_pairwise_binary_parameters():
     assert seen_pairs == expected_pairs
 
 
-def test_cli_invocation_generates_cases(tmp_path):
+def test_cli_invocation_generates_cases():
     script = Path(__file__).resolve().parent.parent / "pairwise.py"
-    cmd = [sys.executable, str(script), "a=0,1", "b=0,1"]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    cmd = [sys.executable, str(script)]
+    user_input = "a\n0,1\nb\n0,1\n\n"
+    result = subprocess.run(
+        cmd, input=user_input, capture_output=True, text=True, check=True
+    )
 
     cases = [json.loads(line) for line in result.stdout.strip().splitlines()]
     seen_pairs = set()


### PR DESCRIPTION
## Summary
- Convert CLI to interactive prompts for supplying parameters
- Document interactive usage in README
- Adjust tests for new prompting behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b174532b3c8329b485e89f3dbf9543